### PR TITLE
Forward url requests to extension to fix source map crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## 0.0.4
+* Fixed a crash due to sourcemaps - [#8](https://github.com/CodeMooseUS/vscode-devtools/issues/8)
+
+## 0.0.3
+* Fixed an issue with telemetry not updating user count correctly
+
+## 0.0.2
+* Added devtools settings persistance - [#1](https://github.com/CodeMooseUS/vscode-devtools/issues/1)
+    * Any settings that you change from within the devtools themselves will now be there next time you open the devtools.
+    * This includes changing the devtools theme which auto reloads the tools.
+* Added anonymous telemetry reporting to see which functions need implementing next based on usage.
+
+## 0.0.1
+* Initial preview release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-devtools-for-chrome",
   "displayName": "DevTools for Chrome",
   "description": "Open the chrome devtools as a dockable webview",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "preview": true,
   "license": "SEE LICENSE IN LICENSE",
   "publisher": "codemooseus",


### PR DESCRIPTION
Previously attaching to a site that had sourcemaps pointing to a local server would cause the devtools webview to crash and show a black window. This was due to the fact that the devtools would attempt to download the sourcemap file via a cross domain xhr call. Doing so would terminate the vscode webview.

The fix is to forward the url download requests over to the extension and then have it perform the download via node. The response is then sent back to the webview and the devtools no longer crash.

Resolves #8 